### PR TITLE
Deprecate start recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,64 +7,67 @@ Please note, at this time we only support iOS. If you are interested in integrat
 ![Short demo of expo-siro](demo.gif)
 
 ### Requirements
+
 - iOS 15+
 
 ### Getting Started
-1. Run `npx expo install expo-siro`
 
+1. Run `npx expo install expo-siro`
 
 2. There are a couple of build settings we will need to tweek, so you'll need to install `expo-build-properties`, by running `npx expo install expo-build-properties`
 
-
 3. In `app.json`, add the following to the config:
+
 ```json
 {
   "expo": {
     "name": "my-app",
     "plugins": [
       [
-		"expo-build-properties", 
-		{
-			"ios": {
-				"deploymentTarget": "15.0",
-				"useFrameworks": "static",
-			}
-		}
-	  ]
+        "expo-build-properties",
+        {
+          "ios": {
+            "deploymentTarget": "15.0",
+            "useFrameworks": "static"
+          }
+        }
+      ]
     ]
   }
 }
 ```
+
 Alternatively, you can add those values to your `Podfile` directly:
+
 ```ruby
 use_frameworks! :linkage => :static
 platform :ios, 15.0
 ```
 
+4. Update your plist directly or via the `app.json` file (recommened if using expo):
 
-4. Update your plist directly or via the `app.json` file (recommened if using expo): 
 ```json
 {
-	"expo": {
-		"ios": {
-			"infoPlist": {
-				"NSLocationWhenInUseUsageDescription": "Add your description here",
-				"NSMicrophoneUsageDescription": "Add description here",
-				"UIBackgroundModes": [ "audio" ]
-			}
-		}
-	}
+  "expo": {
+    "ios": {
+      "infoPlist": {
+        "NSLocationWhenInUseUsageDescription": "Add your description here",
+        "NSMicrophoneUsageDescription": "Add description here",
+        "UIBackgroundModes": ["audio"]
+      }
+    }
+  }
 }
 ```
 
-
 5. Build the iOS app by running: `npx expo run:ios`
-Please note that you must run your expo app in expo development mode via `npx expo run:ios`. Running the app in expo-go (using `npx expo start` will not work as `expo-siro` uses Native Modules. If you do decide that you still would like to use expo go, you can conditioanlly import and use `expo-siro` by using `expo-constants`, see [docs here](https://docs.expo.dev/versions/latest/sdk/constants/#appownership). 
+   Please note that you must run your expo app in expo development mode via `npx expo run:ios`. Running the app in expo-go (using `npx expo start` will not work as `expo-siro` uses Native Modules. If you do decide that you still would like to use expo go, you can conditioanlly import and use `expo-siro` by using `expo-constants`, see [docs here](https://docs.expo.dev/versions/latest/sdk/constants/#appownership).
 
 ### Usage
-1. call `setup` and pass in your `enviornment`. Currently we support `staging` and `production`.
 
-2. Import the `SiroButton` and drop in within any view. `SiroButton` takes no props. The `SiroButton` controls the Siro recording modal. The Siro Recording Modal gets embedded into the root view of your app automatically. 
+1. call `setup` and pass in your `environment`. Currently we support `staging` and `production`.
+
+2. Import the `SiroButton` and drop in within any view. `SiroButton` takes no props. The `SiroButton` controls the Siro recording modal. The Siro Recording Modal gets embedded into the root view of your app automatically.
 
 Please note, users must login before recording, or sending events via the `sendEvent` function. Attempting to record, or `sendEvent`s before logging in will fail. `SiroButton` fully manages the user lifecycle. Upon tapping the `SiroButton` a Login form will be displayed if the user is currently not logged in. If the user is currently logged in, the `SiroButton` will start/stop the recorder. Alternatively, you can show/hide the modal with `showModal` and `hide` functions.
 
@@ -92,93 +95,93 @@ const App = () => {
 }
 ```
 
-
 ## API
 
 ### function setup(env: 'staging' | 'production')
+
 Sets up the SiroSDK. Must be called before utilizing the SDK. If `setup` is not called, interactions with the SiroSDK will fail.
-___
 
+---
 
-### function startRecording()
-Starts a recording. User will be asked for access to their location + microphone upon calling the `startRecording` function if they have not yet given the SiroSDK access. Once access is granted, `startRecording` will begin recording conversations.
 Please note that there can only ever be one active recording instance. User must be logged in.
-___
 
-
-### function stopRecording()
-Stops the currently active recording session. If there is no active recording session, no action is taken.
-___
-
+---
 
 ### function sendEvent(eventName: string, interactionData?: InteractionData)
-Sends an event along with any Lead or Interaction data. Events can trigger actions that control the Siro Recorder. 
+
+Sends an event along with any Lead or Interaction data. Events can trigger actions that control the Siro Recorder.
+
+Please note, events must be configured to start, stop, and pause the recorder. Contact chris@siro.ai for event configuration.
 
 ```typescript
-import { sendEvent } from 'expo-siro'
+import { sendEvent } from "expo-siro";
 
 interface Coordinates {
-	lat: number
-    long: number
+  lat: number;
+  long: number;
 }
 
 interface Address {
-	street: string
-    city: string
-    state: string
-    zip: string
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
 }
 
 interface Stage {
-	id: string
-    name?: string
-    color?: string
-    icon?: string
-    won?: boolean
-    interacted?: boolean
+  id: string;
+  name?: string;
+  color?: string;
+  icon?: string;
+  won?: boolean;
+  interacted?: boolean;
 }
 
 interface Interaction {
-	// id is the unique ID of the interaction in your database.
-	id: string; 
+  // id is the unique ID of the interaction in your database.
+  id: string;
 
-	// Optional fields	
-	// leadId is the unique id of this lead in your database.
-	leadId?: string;
+  // Optional fields
+  // leadId is the unique id of this lead in your database.
+  leadId?: string;
 
-	// userId is the ID of the currently logged in user.
-	userId?: string; 
-	note?: string;
+  // userId is the ID of the currently logged in user.
+  userId?: string;
+  note?: string;
 
-	// stage is the current stage of the lead. If this interaction involved a stage change, use the stage that the lead was changed to.
-	stage?: Stage; 
-	coordinates?: Coordinates;
-	address?: Address;
-	// dateCreated is the date of the interaction. This is most likely the current date.
-	dateCreated?: Date; 
-	// leadDateCreated is the date that this lead was created.
-	leadDateCreated?: Date; 
-	contacts?: Contact[];
-	// metadata is used for any additional data
-	metadata?: { [key: string]: any }; 
+  // stage is the current stage of the lead. If this interaction involved a stage change, use the stage that the lead was changed to.
+  stage?: Stage;
+  coordinates?: Coordinates;
+  address?: Address;
+  // dateCreated is the date of the interaction. This is most likely the current date.
+  dateCreated?: Date;
+  // leadDateCreated is the date that this lead was created.
+  leadDateCreated?: Date;
+  contacts?: Contact[];
+  // metadata is used for any additional data
+  metadata?: { [key: string]: any };
 }
 
 const interactionData = {
-	id: string // Only the ID is required
-}
+  id: string, // Only the ID is required
+};
 
-sendEvent('createLead', interactionData)
+sendEvent("createLead", interactionData);
 ```
-___
 
+---
 
-### function showModal() 
+### function showModal()
+
 Show's the Siro Recording modal. The modal has two states:
+
 - Login Form: Rendered if the user is not currently logged in.
 - Recorder: Rendered if the user has authenticated successfully.
-___
 
+---
 
 ### function hide()
+
 Hides/dismisses the Siro modal.
+
 # expo-siro

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -40,13 +40,6 @@ export default function App() {
     SiroReactNative.setup(SiroReactNative.Environment.staging);
   };
 
-  const startRecording = () => {
-    SiroReactNative.startRecording();
-  };
-
-  const stopRecording = () => {
-    SiroReactNative.stopRecording();
-  };
 
   const sendEvent = (eventName: string, data?: SiroReactNative.Interaction) => {
     SiroReactNative.sendEvent(eventName, data);
@@ -65,30 +58,24 @@ export default function App() {
       <Text style={{ marginBottom: 20 }}>SiroSDK Example App</Text>
       <Text>Is user logged in {String(isLoggedIn)}</Text>
       <Button title="Step 1 - Login to Siro" onPress={showModal} />
-      <Button title="Step 2 - Start Recording!" onPress={startRecording} />
 
       <Text style={{ marginBottom: 20 }}>Test Events</Text>
       <Button
-        title="Step 3 - Send event!"
+        title="Step 2 - Send event!"
         onPress={() => sendEvent("Random Event", interaction)}
       />
       <Button
-        title="Step 4 - Send dropPin event!"
+        title="Step 3 - Send dropPin event!"
         onPress={() => sendEvent("dropPin", interaction)}
       />
       <Button
-        title="Step 5 - Send createLead event!"
+        title="Step 4 - Send createLead event!"
         onPress={() => sendEvent("createLead")}
       />
       <Button
-        title="Step 6 - Send leadClosed event!"
+        title="Step 5 - Send leadClosed event!"
         onPress={() => sendEvent("leadClosed")}
       />
-      <Button
-        title="Step 7 - Stop Recording!"
-        onPress={() => stopRecording()}
-      />
-
       <SiroReactNative.SiroButton />
     </View>
   );

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -42,7 +42,7 @@ target 'siroreactnativeexample' do
   use_expo_modules!
   config = use_native_modules!
   
-  pod 'SiroSDK',  :git => 'https://github.com/Siro-ai/SiroSDK', :tag => '1.3.7'
+  pod 'SiroSDK',  :path => '~/development/siro/SiroSDK', :tag => '1.3.7'
   # pod 'AnyCodable'
 
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -42,7 +42,7 @@ target 'siroreactnativeexample' do
   use_expo_modules!
   config = use_native_modules!
   
-  pod 'SiroSDK',  :path => '~/development/siro/SiroSDK', :tag => '1.3.7'
+  pod 'SiroSDK',  :git => 'https://github.com/Siro-ai/SiroSDK', :tag => '1.3.7'
   # pod 'AnyCodable'
 
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -662,21 +662,21 @@ PODS:
     - React-Core (= 0.72.3)
     - React-jsi (= 0.72.3)
     - ReactCommon/turbomodule/core (= 0.72.3)
-  - FirebaseAppCheckInterop (10.14.0)
+  - FirebaseAppCheckInterop (10.15.0)
   - FirebaseAuth (10.12.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseAuthInterop (10.14.0)
-  - FirebaseCore (10.14.0):
+  - FirebaseAuthInterop (10.15.0)
+  - FirebaseCore (10.15.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.14.0):
+  - FirebaseCoreExtension (10.15.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.14.0):
+  - FirebaseCoreInternal (10.15.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseDynamicLinks (10.12.0):
     - FirebaseCore (~> 10.0)
@@ -698,7 +698,7 @@ PODS:
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseFirestore (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
-  - FirebaseSharedSwift (10.14.0)
+  - FirebaseSharedSwift (10.15.0)
   - FirebaseStorage (10.12.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
@@ -1205,10 +1205,10 @@ PODS:
     - React-jsi (= 0.72.3)
     - React-logger (= 0.72.3)
     - React-perflogger (= 0.72.3)
-  - SiroReactNative (0.5.0):
+  - SiroReactNative (0.7.7):
     - ExpoModulesCore
-    - SiroSDK
-  - SiroSDK (1.3.8):
+    - SiroSDK (~> 1.3.7)
+  - SiroSDK (1.3.7):
     - FirebaseAuth (~> 10.12.0)
     - FirebaseDynamicLinks (~> 10.12.0)
     - FirebaseFirestore (~> 10.12.0)
@@ -1266,7 +1266,7 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - SiroReactNative (from `../../ios`)
-  - SiroSDK (from `~/development/siro/SiroSDK/`)
+  - SiroSDK (from `~/development/siro/SiroSDK`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1390,7 +1390,8 @@ EXTERNAL SOURCES:
   SiroReactNative:
     :path: "../../ios"
   SiroSDK:
-    :path: "~/development/siro/SiroSDK/"
+    :path: "~/development/siro/SiroSDK"
+    :tag: 1.3.7
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -1408,16 +1409,16 @@ SPEC CHECKSUMS:
   ExpoModulesCore: 0a114333f029eaa2edc701334515b4e05343fac3
   FBLazyVector: 4cce221dd782d3ff7c4172167bba09d58af67ccb
   FBReactNativeSpec: c6bd9e179757b3c0ecf815864fae8032377903ef
-  FirebaseAppCheckInterop: c87f1d5421c852413dd936b2b2340b21e62501a0
+  FirebaseAppCheckInterop: a8c555b1c2db1d9445e6c3a08a848167ddb7eb51
   FirebaseAuth: a66c1e14ec58f41d154a4b41ce1a23ea00ad4805
-  FirebaseAuthInterop: 23be77be1ca68e4bd15214f403f807a6ca70d7e0
-  FirebaseCore: 6fc17ac9f03509d51c131298aacb3ee5698b4f02
-  FirebaseCoreExtension: 976638051b1a46b503afce7ec80277f9161f2040
-  FirebaseCoreInternal: d558159ee6cc4b823c2296ecc193de9f6d9a5bb3
+  FirebaseAuthInterop: b566e21e2bc5e44a4d44babc56d05a7e5c10493b
+  FirebaseCore: 2cec518b43635f96afe7ac3a9c513e47558abd2e
+  FirebaseCoreExtension: d3f1ea3725fb41f56e8fbfb29eeaff54e7ffb8f6
+  FirebaseCoreInternal: 2f4bee5ed00301b5e56da0849268797a2dd31fb4
   FirebaseDynamicLinks: 1a387da899779e5ef34f4d6f8bdba882f90d0e67
   FirebaseFirestore: f94c9541515fa4a49af52269bbc50349009424b4
   FirebaseFirestoreSwift: 7a81b69579c3fddaf082a8be08d362a1d9c9cf49
-  FirebaseSharedSwift: 0eec812f08b6ec9e03196fc27635739781513028
+  FirebaseSharedSwift: 34b11d9e675e14ee55e160cb7645bba30a192d14
   FirebaseStorage: 1d7ca8c8953fc61ccacaa7c612696b5402968a0d
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
@@ -1462,11 +1463,11 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 512c567151e391a352e67e04e7a479ddc6f2a0a0
   React-utils: f1d39255e788c280589665da427d574d9ff84df2
   ReactCommon: cda2cdd9f45187316ef45e1cb70e1d2058f9aea1
-  SiroReactNative: 2083f764bb7bb59bbeb33c76ed92a498145d51f8
-  SiroSDK: ccdce045be2318293837035b3a62f15040455e9e
+  SiroReactNative: 1ee920aa4d4abfdff43acf79ecdc950854459fc5
+  SiroSDK: 43eada684aee16cab7cc91db2326ceb7e44a54c5
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
 
-PODFILE CHECKSUM: 05d8d14d088a90cd87aad30d9d1abee55faccb2f
+PODFILE CHECKSUM: 97fcddb1d572d97d13b68284eaad22ff0a95d32d
 
 COCOAPODS: 1.11.3

--- a/ios/SiroReactNativeModule.swift
+++ b/ios/SiroReactNativeModule.swift
@@ -32,20 +32,6 @@ public class SiroReactNativeModule: Module {
         }
         SiroSDK.setup(environment: environmentEnum)
     }
-      
-    Function("startRecording") {
-        DispatchQueue.main.async {
-            SiroSDK.startRecording()
-        }
-      
-    }
-
-    Function("stopRecording") {
-      DispatchQueue.main.async {
-      SiroSDK.stopRecording()
-
-      }
-    }
 
     Function("sendEvent") { (eventName: String, leadData: [String: Any]?) in
         DispatchQueue.main.async {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-siro",
-  "version": "0.5.0",
+  "version": "0.7.7",
   "description": "A React Native wrapper for the iOS SiroSDK",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
-import { NativeModulesProxy, EventEmitter, Subscription } from 'expo-modules-core';
+import {
+  NativeModulesProxy,
+  EventEmitter,
+  Subscription,
+} from "expo-modules-core";
 
 // Import the native module. On web, it will be resolved to SiroReactNative.web.ts
 // and on native platforms to SiroReactNative.ts
-import SiroReactNativeModule from './SiroReactNativeModule';
-import SiroButton from './SiroReactNativeView';
-import { Interaction, Environment } from './types';
-
+import SiroReactNativeModule from "./SiroReactNativeModule";
+import SiroButton from "./SiroReactNativeView";
+import { Interaction, Environment } from "./types";
 
 /**
  * Sets up the SiroSDK.
@@ -29,27 +32,12 @@ export function hide() {
   return SiroReactNativeModule.hide();
 }
 
-
-/**
- * Starts the Siro Recorder, if not already started. Does nothing if a recording is already in progress.
- */
-export function startRecording() {
-  SiroReactNativeModule.startRecording();
-}
-
-/**
- * Stops the Siro Recorder, if not already stopped. Does nothing if a recording is not in progress.
- */
-export function stopRecording() {
-  SiroReactNativeModule.stopRecording();
-}
-
 /**
  * Sends an event, which can trigger recorder actions (e.g., start, stop, or discard a recording).
- * 
+ *
  * Include the `data` parameter to send additional data with the event. The data is specific to the event.
  * If your backend already sends Siro lead and interaction data, it is still important for you to include the data field with the id, leadId, and userId, so Siro can associate recordings with the correct records in your database.
- * 
+ *
  * @param {string} event The event to send.
  * @param {Interaction} data The data to send with the event.
  */
@@ -63,7 +51,5 @@ export function sendEvent(event: string, data?: Interaction) {
 export function showModal() {
   SiroReactNativeModule.showModal();
 }
-
-
 
 export { SiroButton, Environment, Interaction };


### PR DESCRIPTION
This PR deprecates the `startRecording` and `stopRecording` functions + updates the `README`. 

Moving forward the only way to start/stop a recorder is:
- via the Siro Modal UI
- by calling `sendEvent` with an event that is pre-configured to start/stop/pause the recorder.