### PR TITLE
v0.7.7

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -41,8 +41,8 @@ export default function App() {
   };
 
 
-  const sendEvent = (eventName: string, data?: SiroReactNative.Interaction) => {
-    SiroReactNative.sendEvent(eventName, data);
+  const sendEvent = async (eventName: string, data?: SiroReactNative.Interaction) => {
+    await SiroReactNative.sendEvent(eventName, data);
   };
 
   const showModal = () => {

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -42,7 +42,7 @@ target 'siroreactnativeexample' do
   use_expo_modules!
   config = use_native_modules!
   
-  pod 'SiroSDK',  :git => 'https://github.com/Siro-ai/SiroSDK', :tag => '1.3.7'
+  pod 'SiroSDK',  :git => 'https://github.com/Siro-ai/SiroSDK', :tag => '1.3.9'
   # pod 'AnyCodable'
 
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1208,7 +1208,7 @@ PODS:
   - SiroReactNative (0.7.7):
     - ExpoModulesCore
     - SiroSDK (~> 1.3.7)
-  - SiroSDK (1.3.7):
+  - SiroSDK (1.3.9):
     - FirebaseAuth (~> 10.12.0)
     - FirebaseDynamicLinks (~> 10.12.0)
     - FirebaseFirestore (~> 10.12.0)
@@ -1266,7 +1266,7 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - SiroReactNative (from `../../ios`)
-  - SiroSDK (from `~/development/siro/SiroSDK`)
+  - SiroSDK (from `https://github.com/Siro-ai/SiroSDK`, tag `1.3.9`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1390,10 +1390,15 @@ EXTERNAL SOURCES:
   SiroReactNative:
     :path: "../../ios"
   SiroSDK:
-    :path: "~/development/siro/SiroSDK"
-    :tag: 1.3.7
+    :git: https://github.com/Siro-ai/SiroSDK
+    :tag: 1.3.9
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
+
+CHECKOUT OPTIONS:
+  SiroSDK:
+    :git: https://github.com/Siro-ai/SiroSDK
+    :tag: 1.3.9
 
 SPEC CHECKSUMS:
   abseil: 926fb7a82dc6d2b8e1f2ed7f3a718bce691d1e46
@@ -1464,10 +1469,10 @@ SPEC CHECKSUMS:
   React-utils: f1d39255e788c280589665da427d574d9ff84df2
   ReactCommon: cda2cdd9f45187316ef45e1cb70e1d2058f9aea1
   SiroReactNative: 1ee920aa4d4abfdff43acf79ecdc950854459fc5
-  SiroSDK: 43eada684aee16cab7cc91db2326ceb7e44a54c5
+  SiroSDK: 994dbf8cd55fc21c1ecdf0d25245ca7ce8d7e6aa
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
 
-PODFILE CHECKSUM: 97fcddb1d572d97d13b68284eaad22ff0a95d32d
+PODFILE CHECKSUM: 62d71fc981ab23566f0ea3af3494b0ada645a1bc
 
 COCOAPODS: 1.11.3

--- a/ios/SiroReactNative.podspec
+++ b/ios/SiroReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'SiroSDK', '~> 1.3.7'
+  s.dependency 'SiroSDK', '1.3.9'
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',

--- a/ios/SiroReactNativeModule.swift
+++ b/ios/SiroReactNativeModule.swift
@@ -43,10 +43,20 @@ public class SiroReactNativeModule: Module {
         SiroSDK.setup(environment: environmentEnum)
     }
 
-    Function("sendEvent") { (eventName: String, leadData: [String: Any]?) in
+    AsyncFunction("sendEvent") { (eventName: String, leadDataString: String?) in
         DispatchQueue.main.async {
-            SiroSDK.sendEvent(eventName, interactionData: nil)
-        }
+
+           do {
+               if let leadData = leadDataString?.data(using: .utf8) {
+                   let decodedData = try JSONDecoder().decode(InteractionData.self, from: leadData)
+                   SiroSDK.sendEvent(eventName, interactionData: decodedData)
+               } else {
+                   SiroSDK.sendEvent(eventName, interactionData: nil)
+               }
+           } catch {
+            print("An error occurred while calling sendEvent: \(error)")
+           }
+                    }
     }
 
     Function("hide") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,8 @@ export function hide() {
  * @param {string} event The event to send.
  * @param {Interaction} data The data to send with the event.
  */
-export function sendEvent(event: string, data?: Interaction) {
-  SiroReactNativeModule.sendEvent(event, data);
+export async function sendEvent(event: string, data?: Interaction) {
+  return await SiroReactNativeModule.sendEvent(event, data !== undefined ? JSON.stringify(data) : undefined);
 }
 
 /**


### PR DESCRIPTION
This update includes:
- Updated podspec to point to SiroKit version 1.3.9 (latest version)
- Removed `startRecording` and `stopRecording` methods
- Now integrators no longer need to configure events. Any `eventName` can be sent to Siro. Event actions must still be configured.
- Fixed a bug where if the app with the SDK was closed, and re-opened users would need to tap on recording button twice to start recording.
- Fixed a bug where there was a transparent screen overlay if a Toast was shown.
- `sendEvent` function is now async